### PR TITLE
Implement --save flag for emoji downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,22 +5,27 @@ A set of tools to manage your slack emoji. Upload em, download em, download em f
 ## Usage
 
 ```
-Usage: emojme [options]
+  Usage: emojme [options]
 
-Options:
+  Options:
 
-download                 download all emoji from given subdomain
-upload                   upload source emoji to given subdomain
-user-stats               get emoji statistics for given user on given subdomain
-sync                     get emoji statistics for given user on given subdomain
--s, --subdomain [value]  slack subdomain. Can be specified multiple times, paired with respective token. (default: null)
--t, --token [value]      slack user token. ususaly starts xoxp-... Can be specified multiple times, paired with respective subdomains. (default: null)
---user [value]           slack user you'd like to get stats on. Can be specified multiple times for multiple users. (default: null)
---top [value]            the top n users you'd like user emoji statistics on (default: 10)
---src [value]            source file for emoji json you'd like to upload
---no-cache               force a redownload of all cached info.
--h, --help               output usage information
--V, --version            output the version number
+    download                 download all emoji from given subdomain
+    upload                   upload source emoji to given subdomain
+    user-stats               get emoji statistics for given user on given subdomain
+    sync                     get emoji statistics for given user on given subdomain
+    -s, --subdomain [value]  [upload/download/user-stats/sync] slack subdomain. Can be specified multiple times, paired with respective token. (default: null)
+    -t, --token [value]      [upload/download/user-stats/sync] slack user token. ususaly starts xoxp-... Can be specified multiple times, paired with respective subdomains. (default: null)
+    --src [value]            [upload] source file(s) for emoji json you'd like to upload (default: null)
+    --src-subdomain [value]  [sync] subdomain from which to draw emoji for one way sync (default: null)
+    --src-token [value]      [sync] token with which to draw emoji for one way sync (default: null)
+    --dst-subdomain [value]  [sync] subdomain to which to emoji will be added is one way sync (default: null)
+    --dst-token [value]      [sync] token with which emoji will be added for one way sync (default: null)
+    --user [value]           [download, user-stats] slack user you'd like to get stats on. Can be specified multiple times for multiple users. (default: null)
+    --top [value]            [user-stats] the top n users you'd like user emoji statistics on (default: 10)
+    --save                   [download] create local files of the given subdomains emoji
+    --no-cache               [upload/download/user-stats/sync] force a redownload of all cached info.
+    -h, --help               output usage information
+    -V, --version            output the version number
 ```
 
 * Pick any one of [download, upload, user-stats, sync], and provide one or several (subdomain, token) pairs.
@@ -68,6 +73,7 @@ sync                     get emoji statistics for given user on given subdomain
 ```
 ./emojme.js user-stats --subdomain $SUBDOMAIN --token $TOKEN --user $USER
 ```
+* This will create json file ./build/$USER.$SUBDOMAIN.adminList.json
 
 #### get user statistics for multiple users
 ```
@@ -89,6 +95,12 @@ sync                     get emoji statistics for given user on given subdomain
 ```
 ./emojme.js sync --src-subdomain $SUBDOMAIN1 --src-token $TOKEN1 --dst-subdomain $SUBDOMAIN2 --dst-token $TOKEN2
 ```
+
+#### download source content for emoji made by $USER1 and $USER2 in $SUBDOMAIN
+```
+./emojme.js download --save --subdomain $SUBDOMAIN --token $TOKEN --user USER1 --user USER2
+```
+* This will create directories ./build/$SUBDOMAIN/$USER1 and ./build/$SUBDOMAIN/$USER2, each containing that user's emoji
 
 #### Extra maybe helpful commands
 * Getting a list of single attributes from an adminList json:

--- a/emojme.js
+++ b/emojme.js
@@ -50,7 +50,7 @@ function main() {
   authPairs = _.zip(program.subdomain, program.token).concat(srcPairs, dstPairs);
 
   if (program.download && hasValidSubdomainInputs(program)) {
-    return Promise.all(authPairs.map(authPair => new EmojiAdminList(...authPair).get()
+    return Promise.all(authPairs.map(authPair => new EmojiAdminList(...authPair).get(program.cache)
       .then(emojiList => {
         if (program.save) return EmojiAdminList.save(emojiList, authPair[0], program.user);
       })
@@ -62,7 +62,7 @@ function main() {
     return Promise.all(authPairs.map(authPair => new EmojiAdd(...authPair).upload(program.src)));
   } else if (program.userStats && hasValidSubdomainInputs(program)) {
     return Promise.all(authPairs.map(authPair => {
-      return new EmojiAdminList(...authPair).get()
+      return new EmojiAdminList(...authPair).get(program.cache)
         .then(emojiList => program.user ?
           EmojiAdminList.summarizeUser(emojiList, program.user) :
           EmojiAdminList.summarizeSubdomain(emojiList, authPair[0], program.top)
@@ -73,11 +73,11 @@ function main() {
       if (program.subdomain.length < 2)
         return Promise.reject('Sync requires pairs of subdomain / token arguments');
 
-      diffListsPromise = Promise.all(authPairs.map(authPair => new EmojiAdminList(...authPair).get()))
+      diffListsPromise = Promise.all(authPairs.map(authPair => new EmojiAdminList(...authPair).get(program.cache)))
         .then(emojiLists => EmojiAdminList.diff(emojiLists, program.subdomain));
     } else if (hasValidSrcDstInputs(program)) {
       diffListsPromise = Promise.all([srcPairs, dstPairs].map(pairs => {
-        return Promise.all(pairs.map(pair => new EmojiAdminList(...pair).get()))
+        return Promise.all(pairs.map(pair => new EmojiAdminList(...pair).get(program.cache)))
       })).then(([srcEmojiLists, dstEmojiLists]) => EmojiAdminList.diff(
         srcEmojiLists,
         program.srcSubdomain,

--- a/lib/emoji-add.js
+++ b/lib/emoji-add.js
@@ -1,12 +1,14 @@
 const fs = require('fs');
 const _ = require('lodash');
-const superagent = require('superagent');
 
 const SlackClient = require('./slack-client');
 const fileUtils = new(require('./file-utils'));
 
 const ENDPOINT = '/emoji.add';
 
+// Methods to upload emoji to slack.
+// Instance methods require slack client.
+// Static methods do not.
 class EmojiAdd {
   constructor(subdomain, token) {
     this.subdomain = subdomain;
@@ -15,58 +17,16 @@ class EmojiAdd {
     this.endpoint = ENDPOINT;
   }
 
-  getData(path) {
-    return new Promise((resolve, reject) => {
-      if (path.match(/^http.*/)) {
-        superagent.get(path)
-          .buffer(true).parse(superagent.parse.image)
-          .then(res => {
-            resolve(res.body);
-        });
-      } else if (path.match(/^data:/)) {
-        resolve(path);
-      } else if (path.match(/\.(gif|jpg|jpeg|png)/) && fs.existsSync(path)) {
-        resolve(fs.readFileSync(path));
-      } else {
-        reject('Emoji Url does not contain acceptable data');
-      }
-    });
-  }
-
-  //TODO rename parts to multipartSections or something
-  createMultipart(emoji) {
-    return new Promise((resolve, reject) => {
-      if (emoji.is_alias === 1) {
-       resolve({
-          'token': this.token,
-          'name': emoji.name,
-          'mode': 'alias',
-          'alias_for': emoji.alias_for
-        });
-      } else {
-        this.getData(emoji.url).then(emojiData => {
-          resolve({
-            'token': this.token,
-            'name': emoji.name,
-            'mode': 'data',
-            'image': emojiData
-          });
-        });
-      }
-    });
-  }
-
   uploadSingle(emoji) {
-    return this.createMultipart(emoji)
+    return this.constructor.createMultipart(emoji, this.token)
       .then(parts => this.slack.request(this.endpoint, parts))
       .then(body => {
+        process.stdout.write('.');
         if (!body.ok) {
-          console.log(`error on ${emoji.name}: ${body.error}`);
+          console.log(`\nerror on ${emoji.name}: ${body.error}`);
           return Object.assign({}, emoji, { error: body.error });
-        } else {
-          console.log(`uploaded ${emoji.name}`);
-          return false;
         }
+        return false;
       }).catch(err => { console.log(err) })
   }
 
@@ -105,6 +65,29 @@ class EmojiAdd {
       });
     });
   }
+
+  static createMultipart(emoji, token) {
+    return new Promise((resolve, reject) => {
+      if (emoji.is_alias === 1) {
+       resolve({
+          'token': token,
+          'name': emoji.name,
+          'mode': 'alias',
+          'alias_for': emoji.alias_for
+        });
+      } else {
+        FileUtils.getData(emoji.url).then(emojiData => {
+          resolve({
+            'token': token,
+            'name': emoji.name,
+            'mode': 'data',
+            'image': emojiData
+          });
+        });
+      }
+    });
+  }
+
 }
 
 module.exports = EmojiAdd;

--- a/lib/emoji-add.js
+++ b/lib/emoji-add.js
@@ -1,4 +1,4 @@
-const fs = require('fs');
+const fs = require('graceful-fs');
 const _ = require('lodash');
 
 const SlackClient = require('./slack-client');

--- a/lib/emoji-admin-list.js
+++ b/lib/emoji-admin-list.js
@@ -34,11 +34,11 @@ class EmojiAdminList {
     }
   }
 
-  get() {
+  get(shouldCache) {
     let path = `./build/${this.subdomain}.adminList.json`;
 
     return new Promise((resolve, reject) => {
-      if (fileUtils.isExpired(path)) {
+      if (!shouldCache || fileUtils.isExpired(path)) {
         this.getAdminListPages().then(emojiLists => {
           let fullList = [].concat.apply([], emojiLists);
           fileUtils.writeJson(path, fullList);

--- a/lib/emoji-admin-list.js
+++ b/lib/emoji-admin-list.js
@@ -1,7 +1,8 @@
 const _ = require('lodash');
 
 const SlackClient = require('./slack-client');
-const fileUtils = new(require('./file-utils'));
+const FileUtils = require('./file-utils');
+const fileUtils = new FileUtils();
 
 const ENDPOINT = '/emoji.adminList';
 const PAGE_SIZE = 500;
@@ -9,6 +10,8 @@ const PAGE_SIZE = 500;
 // Methods and datastructures to retrieve
 // parse, compare, and summarize results from
 // the "emoji admin list" endpoint.
+// Instace methods require slack client.
+// Static methods do not.
 class EmojiAdminList {
   constructor(subdomain, token) {
     this.subdomain = subdomain;
@@ -58,8 +61,11 @@ class EmojiAdminList {
       this.endpoint,
       this.createMultipart(1)
     ).then(body => {
+      if (!body.ok) {
+        return Promise.reject(`Slack request failed with error ${body.error}`);
+      }
       if (!body.emoji || body.emoji.length === 0) {
-        reject('Slack is not returning any emoji');
+        return Promise.reject('Slack is not returning any emoji');
       }
       let pages = body.paging.pages;
       let promiseArray = [Promise.resolve(body.emoji)];
@@ -83,6 +89,7 @@ class EmojiAdminList {
 
       return Promise.all(promiseArray).then(emojiLists => emojiLists.filter(Boolean));
     }).catch(err => {
+      console.log(err);
       console.log(`Unable to create slack client and retrieve AdminList`);
     });
   }
@@ -119,14 +126,14 @@ class EmojiAdminList {
     }).filter(Boolean);
   }
 
-  summarizeSubdomain(emojiList, n) {
+  static summarizeSubdomain(emojiList, subdomain, n) {
     let groupedEmoji = _.countBy(emojiList, 'user_display_name');
 
     let sortedUsers = _.chain(groupedEmoji)
       .map((count, user) => { return {user: user, count: count}})
       .orderBy('count', 'desc')
       .value();
-    console.log(`The top ${n} contributors for ${this.subdomain}'s ${emojiList.length} emoji are:`);
+    console.log(`The top ${n} contributors for ${subdomain}'s ${emojiList.length} emoji are:`);
     sortedUsers.slice(0, n).forEach((obj, index) => {
       console.log(`#${index+1}: ${obj.user} with ${obj.count} emoji`);
     });
@@ -136,17 +143,46 @@ class EmojiAdminList {
     dstLists = dstLists || srcLists;
     dstSubdomains = dstSubdomains || srcSubdomains;
 
-    let diffsToUpload = [];
+    let diffs = [];
     let uniqEmojiList = _.unionBy(...srcLists, 'name');
 
     _.zipWith(dstSubdomains, dstLists, (dstSubdomain, dstEmojiList) => {
       let missingEmojiList = _.differenceBy(uniqEmojiList, dstEmojiList, 'name');
       let path = `./build/diff.to-${dstSubdomain}.from-${_.without(srcSubdomains, dstSubdomain).join('-')}.adminList.json`;
       fileUtils.writeJson(path, missingEmojiList);
-      diffsToUpload.push({subdomain: dstSubdomain, emojiList: missingEmojiList});
+      diffs.push({subdomain: dstSubdomain, emojiList: missingEmojiList});
     });
 
-    return diffsToUpload;
+    return diffs;
+  }
+
+  static save(emojiList, subdomain, users) {
+    users = users.length > 0 ? users : ['all'];
+    let groupedEmoji = _.groupBy(emojiList, 'user_display_name');
+    let promiseArray = [];
+
+    users.forEach(user => {
+      if (user != 'all' && !(user in groupedEmoji)) {
+        console.log(`Could not find ${user} in emoji contributors`);
+        return Promise.resolve();
+      }
+
+      console.log(`Found ${groupedEmoji[user].length} emoji to save by ${user}.`);
+      let dirPath = `build/${subdomain}/${user}`;
+      FileUtils.mkdirp(dirPath);
+
+      groupedEmoji[user].forEach(emoji => {
+        let fileType = emoji.url.split('.').slice(-1);
+        let path = `${dirPath}/${emoji.name}.${fileType}`;
+
+        promiseArray.push(FileUtils.getData(emoji.url)
+          .then(emojiData => FileUtils.saveData(emojiData, path))
+          .then(() => process.stdout.write('.'))
+        )
+      });
+    });
+
+    return Promise.all(promiseArray).then(() => emojiList);
   }
 }
 

--- a/lib/file-utils.js
+++ b/lib/file-utils.js
@@ -1,4 +1,4 @@
-const fs = require('fs');
+const fs = require('graceful-fs');
 const json = require('json');
 const superagent = require('superagent');
 const Throttle = require('superagent-throttle');

--- a/lib/file-utils.js
+++ b/lib/file-utils.js
@@ -1,7 +1,15 @@
 const fs = require('fs');
 const json = require('json');
+const superagent = require('superagent');
+const Throttle = require('superagent-throttle');
 
 const MAX_AGE = (1000 * 60 * 60 * 24); // one day
+const throttle = new Throttle({
+  active: true,
+  concurrent: 20,
+  rate: Infinity
+});
+
 
 class FileUtils {
   constructor(maxAge) {
@@ -10,8 +18,16 @@ class FileUtils {
     this.currentTime = Date.now();
     this.maxAge = this.currentTime - maxAge;
 
-    if (!fs.existsSync('./build'))
-      fs.mkdirSync('./build');
+    this.constructor.mkdirp('build');
+  }
+
+  static mkdirp(path) {
+    let dirs = path.split('/');
+    for (let i = 1; i <= dirs.length; i++) {
+      let subPath = dirs.slice(0, i).join('/');
+      if (!fs.existsSync(subPath))
+        fs.mkdirSync(subPath);
+    }
   }
 
   writeJson(path, data) {
@@ -37,6 +53,35 @@ class FileUtils {
       return false;
     }
   }
+
+  static saveData(data, path) {
+    return new Promise((resolve, reject) => {
+      fs.writeFile(path, data, {encoding: 'base64'}, (err) => {
+        if (err) reject(err);
+        resolve(path);
+      });
+    });
+  }
+
+  static getData(path) {
+    return new Promise((resolve, reject) => {
+      if (path.match(/^http.*/)) {
+        superagent.get(path)
+          .use(throttle.plugin())
+          .buffer(true).parse(superagent.parse.image)
+          .then(res => {
+            resolve(res.body);
+        });
+      } else if (path.match(/^data:/)) {
+        resolve(path);
+      } else if (path.match(/\.(gif|jpg|jpeg|png)/) && fs.existsSync(path)) {
+        resolve(fs.readFileSync(path));
+      } else {
+        reject('Emoji Url does not contain acceptable data');
+      }
+    });
+  }
+
 }
 
 module.exports = FileUtils;

--- a/package-lock.json
+++ b/package-lock.json
@@ -220,6 +220,11 @@
         "path-is-absolute": "^1.0.0"
       }
     },
+    "graceful-fs": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+    },
     "growl": {
       "version": "1.10.5",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "license": "ISC",
   "dependencies": {
     "commander": "^2.17.1",
+    "graceful-fs": "^4.1.11",
     "http-debug": "^0.1.2",
     "json": "^9.0.6",
     "lodash": "^4.17.10",

--- a/spec/unit/lib/emoji-admin-list-spec.js
+++ b/spec/unit/lib/emoji-admin-list-spec.js
@@ -4,7 +4,7 @@ const sinon = require('sinon');
 let EmojiAdminList = require('../../../lib/emoji-admin-list');
 let SlackClient = require('../../../lib/slack-client');
 let FileUtils = require('../../../lib/file-utils');
-let fs = require('fs');
+let fs = require('graceful-fs');
 
 let specHelper = require('../../spec-helper');
 


### PR DESCRIPTION
#What

This change adds a `--save` flag to be used with the `download` action (See README.md for example) to download all emoji source files in addition to just their metadata returned from the `adminList` endpoint. 

There are also a couple other fixes in here, like respecting `--no-cache` and reorganizing some promises.

# Why

A noid person may not worry about slack putting their emoji image links behind some kind of auth. But i'm not noid. I'm paranoid. I want to have a away to get back the emoji I upload, and this implementation doubles as a better way to be selective about which emoji get moved when you migrate between subdomains. Instead of just going on a json of names, you can look at a directory of images! That's great.

