### PR TITLE
Sort out static methods

### DIFF
--- a/emojme-add.js
+++ b/emojme-add.js
@@ -56,9 +56,9 @@ async function add(subdomains, tokens, options) {
       });
     }
 
-    return emojiAdd.upload(srcEmojiList).then([emojiList, errorList] => {
-      if (errorList.length > 0 && options.output)
-        FileUtils.writeJson(path, errorJson);
+    return emojiAdd.upload(srcEmojiList).then(results => {
+      if (results.errorList.length > 0 && options.output)
+        FileUtils.writeJson(`./build/${this.subdomain}.emojiUploadErrors.json`, errorJson);
     });
   });
 

--- a/emojme-add.js
+++ b/emojme-add.js
@@ -13,7 +13,7 @@ if (require.main === module) {
     .option('--src <value>', 'source file(s) for emoji json you\'d like to upload', Util.list, null)
     .option('--name <value>', 'name of the emoji from --src that you\'d like to upload', Util.list, null)
     .option('--alias-for <value>', 'name of the emoji you\'d like --name to be an alias of. Specifying this will negate --src', Util.list, null)
-    .option('--bust-cache', 'force a redownload of all cached info.')
+    .option('--bust-cache', 'force a redownload of all cached info.', false)
     .option('--no-output', 'prevent writing of files.')
     .parse(process.argv)
 

--- a/emojme-add.js
+++ b/emojme-add.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
+const FileUtils = require('./file-utils');
 const EmojiAdminList = require('./lib/emoji-admin-list');
 const EmojiAdd = require('./lib/emoji-add');
 const Util = require('./lib/util');
@@ -55,7 +56,10 @@ async function add(subdomains, tokens, options) {
       });
     }
 
-    return await emojiAdd.upload(srcEmojiList);
+    return emojiAdd.upload(srcEmojiList).then([emojiList, errorList] => {
+      if (errorList.length > 0 && options.output)
+        FileUtils.writeJson(path, errorJson);
+    });
   });
 
   return Promise.all(addPromises);

--- a/emojme-download.js
+++ b/emojme-download.js
@@ -30,7 +30,7 @@ async function download(subdomains, tokens, options) {
   let [authPairs] = Util.zipAuthPairs(subdomains, tokens);
 
   let downloadPromises = authPairs.map(async authPair => {
-    let adminList = new EmojiAdminList(...authPair);
+    let adminList = new EmojiAdminList(...authPair, options.output);
     let emojiList = await adminList.get(options.bustCache);
     if (options.save)
       return await EmojiAdminList.save(emojiList, authPair[0], options.user);

--- a/emojme-download.js
+++ b/emojme-download.js
@@ -10,7 +10,7 @@ if (require.main === module) {
   Util.requireAuth(program)
     .option('--user <value>', 'slack user you\'d like to get stats on. Can be specified multiple times for multiple users.', Util.list, null)
     .option('--save', 'create local files of the given subdomain\s emoji')
-    .option('--bust-cache', 'force a redownload of all cached info.')
+    .option('--bust-cache', 'force a redownload of all cached info.', false)
     .option('--no-output', 'prevent writing of files.')
     .parse(process.argv)
 

--- a/emojme-sync.js
+++ b/emojme-sync.js
@@ -43,7 +43,10 @@ async function sync(subdomains, tokens, options) {
     let diffs = EmojiAdminList.diff(emojiLists, subdomains);
     uploadedDiffPromises = diffs.map(diffObj => {
       let emojiAdd = new EmojiAdd(diffObj.subdomain, _.find(authPairs, [0, diffObj.subdomain])[1]);
-      return emojiAdd.upload(diffObj.emojiList);
+      return emojiAdd.upload(diffObj.emojiList).then(results => {
+        if (results.errorList.length > 0 && options.output)
+          FileUtils.writeJson(`./build/${this.subdomain}.emojiUploadErrors.json`, errorJson);
+      });
     });
   } else if (srcPairs && dstPairs) {
     let srcDstPromises = [srcPairs, dstPairs].map(pairs =>
@@ -60,7 +63,10 @@ async function sync(subdomains, tokens, options) {
         _.find(authPairs, [0, diffObj.subdomain])[1],
         options.output
       );
-      return emojiAdd.upload(diffObj.emojiList);
+      return emojiAdd.upload(diffObj.emojiList).then(results => {
+        if (results.errorList.length > 0 && options.output)
+          FileUtils.writeJson(`./build/${this.subdomain}.emojiUploadErrors.json`, errorJson);
+      });
     });
   } else {
     throw new Error('Invalid Input');

--- a/emojme-upload.js
+++ b/emojme-upload.js
@@ -9,7 +9,7 @@ if (require.main === module) {
 
   Util.requireAuth(program)
     .option('--src <value>', 'source file(s) for emoji json you\'d like to upload', Util.list, null)
-    .option('--bust-cache', 'force a redownload of all cached info.')
+    .option('--bust-cache', 'force a redownload of all cached info.', false)
     .option('--no-output', 'prevent writing of files.')
     .parse(process.argv)
 

--- a/emojme-upload.js
+++ b/emojme-upload.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const _ = require('lodash');
-const EmojiAdminList = require('./lib/emoji-admin-list');
 const EmojiAdd = require('./lib/emoji-add');
 const Util = require('./lib/util');
 

--- a/lib/emoji-add.js
+++ b/lib/emoji-add.js
@@ -48,18 +48,13 @@ class EmojiAdd {
     let resultArray = emojiResultArray.concat(aliasResultArray);
 
     let errors = _.filter(resultArray);
-    let path = `./build/${this.subdomain}.emojiUploadErrors.json`;
     let errorJson = _.groupBy(errors, 'error');
 
     let totalCount = resultArray.length;
     let errorsCount = errors.length;
     let successCount = totalCount - errorsCount;
-    console.log(`Out of ${totalCount} requests, encountered ${successCount} successes`);
-    if (errorsCount > 0) {
-      if (this.output) FileUtils.writeJson(path, errorJson);
-      console.log(`And ${errorsCount} errors. View them in ${path}`);
-    }
-    return {emojiList: masterList, errorsList: errors};
+    console.log(`\nrequests: ${totalCount} \nsuccesses: ${successCount} \nerrors: ${errorsCount}`);
+    return {subdomain: subdomain, emojiList: masterList, errorList: errors};
   }
 
   static async createMultipart(emoji, token) {

--- a/lib/emoji-add.js
+++ b/lib/emoji-add.js
@@ -54,7 +54,7 @@ class EmojiAdd {
     let errorsCount = errors.length;
     let successCount = totalCount - errorsCount;
     console.log(`\nrequests: ${totalCount} \nsuccesses: ${successCount} \nerrors: ${errorsCount}`);
-    return {subdomain: subdomain, emojiList: masterList, errorList: errors};
+    return {subdomain: this.subdomain, emojiList: masterList, errorList: errors};
   }
 
   static async createMultipart(emoji, token) {

--- a/lib/emoji-admin-list.js
+++ b/lib/emoji-admin-list.js
@@ -98,16 +98,15 @@ class EmojiAdminList {
       let aliases = userTotal - originals;
       let percentage = (((userTotal * 1.0) / emojiList.length) * 100.0).toPrecision(4);
 
-      console.log(`${user} has created ${userTotal} emoji, ${originals} originals and ${aliases} aliases, ${percentage}% of the total emoji population`);
-
-      let safeUserName = user.toLowerCase().replace(/ /g, '-');
-      FileUtils.writeJson(`./build/${safeUserName}.${subdomain}.adminList.json`, userEmoji, null, 3);
+      console.log(`${user}'s emoji: \n\ttotal: ${userTotal} \n\toriginals: ${originals} \n\taliases: ${aliases} \n\tpercentage:${percentage}%`);
 
       return {
         user: user,
-        originals: originals,
-        aliases: aliases,
-        total: userTotal,
+        userEmoji: userEmoji,
+        subdomain: subdomain,
+        originalCount: originals,
+        aliasCount: aliases,
+        totalCount: userTotal,
         percentage: percentage
       };
     }).filter(Boolean);
@@ -122,11 +121,8 @@ class EmojiAdminList {
       .value();
     console.log(`The top ${n} contributors for ${subdomain}'s ${emojiList.length} emoji are:`);
     let topUsers = sortedUsers.slice(0, n);
-    topUsers.forEach((obj, index) => {
-      console.log(`#${index+1}: ${obj.user} with ${obj.count} emoji`);
-    });
-
-    return topUsers;
+    debugger;
+    return this.summarizeUser(emojiList, subdomain, topUsers.map(e => e.user));
   }
 
   static diff(srcLists, srcSubdomains, dstLists, dstSubdomains) {
@@ -138,9 +134,7 @@ class EmojiAdminList {
 
     _.zipWith(dstSubdomains, dstLists, (dstSubdomain, dstEmojiList) => {
       let missingEmojiList = _.differenceBy(uniqEmojiList, dstEmojiList, 'name');
-      let path = `./build/diff.to-${dstSubdomain}.from-${_.without(srcSubdomains, dstSubdomain).join('-')}.adminList.json`;
-      FileUtils.writeJson(path, missingEmojiList);
-      diffs.push({subdomain: dstSubdomain, emojiList: missingEmojiList});
+      diffs.push({dstSubdomain: dstSubdomain, srcSubdomains:_.without(srcSubdomains, dstSubdomains), emojiList: missingEmojiList});
     });
 
     return diffs;

--- a/lib/file-utils.js
+++ b/lib/file-utils.js
@@ -1,7 +1,7 @@
-const fs = require('graceful-fs');
 const json = require('json');
 const superagent = require('superagent');
 const Throttle = require('superagent-throttle');
+const fs = require('graceful-fs');
 
 const MAX_AGE = (1000 * 60 * 60 * 24); // one day
 const throttle = new Throttle({
@@ -20,7 +20,6 @@ function mkdirp(path) {
 }
 
 function writeJson(path, data) {
-  debugger;
   this.mkdirp('build');
   fs.writeFileSync(
     path,

--- a/lib/util.js
+++ b/lib/util.js
@@ -41,6 +41,7 @@ function zipAuthPairs(subdomains, tokens, options) {
 
   authPairs = _.uniq(_.zip(subdomains, tokens).concat(srcPairs, dstPairs));
 
+  debugger;
   if (!atLeastOneValidInputType(subdomains, tokens, options)) {
     throw new Error('Invalid input. Ensure that every given "subdomain" has a matching "token"');
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "emoji-tools",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "engines": {
     "node": ">=10.0.0"
   },

--- a/spec/unit/lib/emoji-add-spec.js
+++ b/spec/unit/lib/emoji-add-spec.js
@@ -93,7 +93,7 @@ describe('EmojiAdd', () => {
       );
 
       emojiAdd.upload('./spec/fixtures/emojiList.json').then(results => {
-        assert.deepEqual(results.errorsList, []);
+        assert.deepEqual(results.errorList, []);
         done();
       });
     });
@@ -104,7 +104,7 @@ describe('EmojiAdd', () => {
       );
 
       emojiAdd.upload(specHelper.testEmojiList(2)).then(results => {
-        assert.deepEqual(results.errorsList, []);
+        assert.deepEqual(results.errorList, []);
         done();
       });
     });
@@ -117,7 +117,7 @@ describe('EmojiAdd', () => {
       );
 
       emojiAdd.upload('./spec/fixtures/emojiList.json').then(results => {
-        assert.deepEqual(results.errorsList, []);
+        assert.deepEqual(results.errorList, []);
 
         let calls = emojiAdd.uploadSingle.getCalls();
         assert.equal(calls[0].args[0].name, 'emoji 1');

--- a/spec/unit/lib/emoji-admin-list-spec.js
+++ b/spec/unit/lib/emoji-admin-list-spec.js
@@ -158,7 +158,7 @@ describe('EmojiAdminList', () => {
     it('returns sorted list of contributors', () => {
       let result = EmojiAdminList.summarizeSubdomain(emojiList, 'subdomain', 10);
 
-      assert.isAbove(result[0].count, result[1].count);
+      assert.isAbove(result[0].totalCount, result[1].totalCount);
     });
 
     it('returns all contributors if count > number of contributors', () => {
@@ -184,10 +184,10 @@ describe('EmojiAdminList', () => {
         let dstSubdomains = ['dst 1', 'dst 2'];
 
         let [diffTo1, diffTo2] = EmojiAdminList.diff(srcLists, srcSubdomains, dstLists, dstSubdomains);
-        assert.equal(diffTo1.subdomain, 'dst 1');
+        assert.equal(diffTo1.dstSubdomain, 'dst 1');
         assert.equal(diffTo1.emojiList.length, 5);
 
-        assert.equal(diffTo2.subdomain, 'dst 2');
+        assert.equal(diffTo2.dstSubdomain, 'dst 2');
         assert.equal(diffTo2.emojiList.length, 0);
       });
 
@@ -199,7 +199,7 @@ describe('EmojiAdminList', () => {
 
         let [diffTo1] = EmojiAdminList.diff(srcLists, srcSubdomains, dstLists, dstSubdomains);
 
-        assert.equal(diffTo1.subdomain, 'dst 1');
+        assert.equal(diffTo1.dstSubdomain, 'dst 1');
         assert.equal(diffTo1.emojiList.length, 19);
       });
     });
@@ -210,10 +210,10 @@ describe('EmojiAdminList', () => {
         let subdomains = ['sub 1', 'sub 2'];
 
         let [diffTo1, diffTo2] = EmojiAdminList.diff(lists, subdomains);
-        assert.equal(diffTo1.subdomain, 'sub 1');
+        assert.equal(diffTo1.dstSubdomain, 'sub 1');
         assert.equal(diffTo1.emojiList.length, 5);
 
-        assert.equal(diffTo2.subdomain, 'sub 2');
+        assert.equal(diffTo2.dstSubdomain, 'sub 2');
         assert.equal(diffTo2.emojiList.length, 0);
       });
 
@@ -223,13 +223,13 @@ describe('EmojiAdminList', () => {
 
         let [diffTo1, diffTo2, diffTo3] = EmojiAdminList.diff(lists, subdomains);
 
-        assert.equal(diffTo1.subdomain, 'sub 1');
+        assert.equal(diffTo1.dstSubdomain, 'sub 1');
         assert.equal(diffTo1.emojiList.length, 15);
 
-        assert.equal(diffTo2.subdomain, 'sub 2');
+        assert.equal(diffTo2.dstSubdomain, 'sub 2');
         assert.equal(diffTo2.emojiList.length, 10);
 
-        assert.equal(diffTo3.subdomain, 'sub 3');
+        assert.equal(diffTo3.dstSubdomain, 'sub 3');
         assert.equal(diffTo3.emojiList.length, 0);
       });
     });
@@ -255,18 +255,18 @@ describe('EmojiAdminList', () => {
 
       let [diffTo1, diffTo2, diffTo3] = EmojiAdminList.diff(lists, subdomains);
 
-      assert.equal(diffTo1.subdomain, 'sub 1');
+      assert.equal(diffTo1.dstSubdomain, 'sub 1');
       assert.deepEqual(diffTo1.emojiList, [
         {name: 'present-in-2-and-3'},
         {name: 'present-in-3'}
       ]);
 
-      assert.equal(diffTo2.subdomain, 'sub 2');
+      assert.equal(diffTo2.dstSubdomain, 'sub 2');
       assert.deepEqual(diffTo2.emojiList, [
         {name: 'present-in-3'}
       ]);
 
-      assert.equal(diffTo3.subdomain, 'sub 3');
+      assert.equal(diffTo3.dstSubdomain, 'sub 3');
       assert.deepEqual(diffTo3.emojiList, [
         {name: 'present-in-1-and-2'}
       ]);

--- a/spec/unit/lib/util-spec.js
+++ b/spec/unit/lib/util-spec.js
@@ -48,7 +48,7 @@ describe('Util', () => {
 
     it('throws an error when src/dst auth pairs are mismatched', () => {
       let subdomains = ['subdomain 1'];
-      let tokens = ['token 1'];
+      let tokens = [];
       let options = {
         srcSubdomains: ['src subdomain 1', 'src subdomain 2'],
         srcTokens: [],


### PR DESCRIPTION
if we want to be able to suppress output based on a cli flag, we need to be able to tell static methods not to output. we could do that with a new method arg which feels clumsy, we could make the static methods non static which is organizationally non ideal, or we could pull code that is non-static out of the static methods. that seems to be the best choice.