### PR TITLE
Allow fresh slack instances to accept emoji

### DIFF
--- a/lib/emoji-admin-list.js
+++ b/lib/emoji-admin-list.js
@@ -54,8 +54,8 @@ class EmojiAdminList {
     if (!firstPageBody.ok) {
       throw new Error(`Slack request failed with error ${firstPageBody.error}`);
     }
-    if (!firstPageBody.emoji || firstPageBody.emoji.length === 0) {
-      throw new Error('Slack is not returning any emoji');
+    if (!firstPageBody.emoji) {
+      throw new Error('Unable to retrieve first page of emoji');
     }
 
     const { pages } = firstPageBody.paging;

--- a/spec/integration/emojme-sync-spec.js
+++ b/spec/integration/emojme-sync-spec.js
@@ -43,7 +43,7 @@ describe('sync', () => {
 
     // prevent writing during tests
     sandbox.stub(FileUtils, 'saveData').callsFake((arg1, arg2) => Promise.resolve(arg2));
-    sandbox.stub(FileUtils, 'mkdirp');
+    sandbox.stub(FileUtils, 'writeJson');
   });
 
   describe('syncs one directionally when src and dst auth pairs are specified', () => {

--- a/spec/integration/emojme-user-stats-spec.js
+++ b/spec/integration/emojme-user-stats-spec.js
@@ -29,7 +29,7 @@ describe('user-stats', () => {
 
     // prevent writing during tests
     sandbox.stub(FileUtils, 'saveData').callsFake((arg1, arg2) => Promise.resolve(arg2));
-    sandbox.stub(FileUtils, 'mkdirp');
+    sandbox.stub(FileUtils, 'writeJson');
   });
 
   describe('when one user is given it returns their user stats', () => {


### PR DESCRIPTION
Closes https://github.com/jackellenberger/emojme/issues/24

There was an arbitrary limitation that all slack instances must have existing custom emoji. that's gone now.