### PR TITLE
 Address new(ish) rate limiting rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,15 @@ Usage: emojme [command] [options]
 
 Commands: (pick 1)
   download                 download all emoji from given subdomain to json
-      -s, --subdomain <value>  slack subdomain. Can be specified multiple times, paired with respective token.
-      -t, --token <value>      slack user token. ususaly starts xox*-... Can be specified multiple times, paired with respective subdomains.
-      --save <user>            save all of <user>'s emoji to disk. specify "all" to save all emoji.
+      -s, --subdomain <value>  slack subdomain. Can be specified multiple times, paired with respective token. (default: )
+      -t, --token <value>      slack user token. ususaly starts xox*-... Can be specified multiple times, paired with respective subdomains. (default: )
       --bust-cache             force a redownload of all cached info.
-      --no-output              prevent writing of files.
+      --no-output              prevent writing of files in build/ and log/
+      --verbose                log debug messages to console
+      --save <user>            save all of <user>'s emoji to disk at build/$subdomain/$user
+      --save-all               save all emoji from all users to disk at build/$subdomain
+      --save-all-by-user       save all emoji from all users to disk at build/$subdomain/$user
+      -h, --help               output usage information
 
   upload                   upload emoji from json to given subdomain
       -s, --subdomain <value>  slack subdomain. Can be specified multiple times, paired with respective token.
@@ -423,7 +427,7 @@ SLACK_REQUEST_WINDOW
 SLACK_REQUEST_CONCURRENCY=10 \
 SLACK_REQUEST_RATE=200 \
 SLACK_REQUEST_WINDOW=60000 \
-./emojme.js download --subdomain $SUBDOMAIN --token $TOKEN --saveAll --bust-cache
+./emojme.js download --subdomain $SUBDOMAIN --token $TOKEN --save-all --bust-cache
 
 ```
 I have tried my darndest to make the slack client in this project 429 tolerant, but after a few ignored 429's Slack gets mean and says you can't try again, so have fun dealing with that.

--- a/README.md
+++ b/README.md
@@ -385,7 +385,7 @@ There are other fields in an adminList, but no others are used at the current ti
 ./emojme.js sync --src-subdomain $SUBDOMAIN1 --src-token $TOKEN1 --dst-subdomain $SUBDOMAIN2 --dst-token $TOKEN2
 ```
 
-## Extra maybe helpful pro moves commands
+## Pro Moves :promoves:
 
 ### Getting a list of single attributes from an adminList json:
 
@@ -403,6 +403,38 @@ window.prompt("your api token is: ",/api_token: "(.*)"/.exec(document.body.inner
 ```
 You will be prompted with your api token! From what I can tell these last anywhere from a few days to indefinitely. Currently, user tokens follow the format:
 `xox[sp]-(\w{12}|\w{10})-(\w{12}|\w{11})-\w{12}-\w{64}` but admittedly I have a small sample size.
+
+### Rate limiting and you
+
+Slack [threatened to release](https://api.slack.com/changelog/2018-03-great-rate-limits) then [released](https://api.slack.com/docs/rate-limits) rate limiting rules across its new api endpoints, and the rollout has included their undocumented endpoints now as well. As such, Emojme is going to slow down :capysad: Another nail in the coffin of making this a useful slackbot.
+
+Though it is unpublished, I have on good authority that `/emoji.adminList` is Tier 3 (when paginated) and `/emoji.add` is Tier 2, so emojme now has a "fast part" and a "slow part" respectively.
+
+I'm not one to judge how a person uses their own credentials, so there is a work around for those looking to get a bit more personal with the Slack networking infra team; Use the following environment variables to override my conservative defaults:
+```sh
+# How many requests to make at a time. Higher numbers are faster (as long as the other two params allow) and more prone to trip Slack's "hey that's not a burst that's a malicous user" alarm
+SLACK_REQUEST_CONCURRENCY
+# How many requests are to be sent per unit time. This is the real control of speed, the higher the more likely you are to be rate limited.
+SLACK_REQUEST_RATE
+# The unit of time, in ms. The lower the number the faster.
+SLACK_REQUEST_WINDOW
+
+# So, an example that has 10 in-flight requests at a time at a maximum rate of 200 requests per minute would be:
+SLACK_REQUEST_CONCURRENCY=10 \
+SLACK_REQUEST_RATE=200 \
+SLACK_REQUEST_WINDOW=60000 \
+./emojme.js download --subdomain $SUBDOMAIN --token $TOKEN --saveAll --bust-cache
+
+```
+I have tried my darndest to make the slack client in this project 429 tolerant, but after a few ignored 429's Slack gets mean and says you can't try again, so have fun dealing with that.
+
+### FAQ
+
+* I don't see any progress when I run a cli command
+  * Do you have `--verbose` in your command? that's pretty useful.
+
+* My network requests are slow and jerky
+  * That's how we gotta live under [rate limiting](#rate-limiting-and-you). To speed things up, try the env vars that are listed, but things might not go well. To make things less jerkey, knock down the concurrency so requests are more serial and there is no down time between bursts.
 
 ## Inspirations
 * [emojipacks](https://github.com/lambtron/emojipacks) is my OG. It mostly worked but seems rather undermaintained.

--- a/docs/emojme-download.js.html
+++ b/docs/emojme-download.js.html
@@ -159,7 +159,7 @@ async function download(subdomains, tokens, options) {
     const emojiList = await adminList.get(options.bustCache);
     if ((options.save &amp;&amp; options.save.length) || options.saveAll || options.saveAllByUser) {
       saveResults = saveResults.concat(await EmojiAdminList.save(emojiList, subdomain, {
-        save: options.save, saveAll: options.saveAll, saveAllByUser: options.saveAllByUser
+        save: options.save, saveAll: options.saveAll, saveAllByUser: options.saveAllByUser,
       }));
     }
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -107,11 +107,15 @@ npm install</code></pre><ul>
 
 Commands: (pick 1)
   download                 download all emoji from given subdomain to json
-      -s, --subdomain &lt;value>  slack subdomain. Can be specified multiple times, paired with respective token.
-      -t, --token &lt;value>      slack user token. ususaly starts xox*-... Can be specified multiple times, paired with respective subdomains.
-      --save &lt;user>            save all of &lt;user>'s emoji to disk. specify &quot;all&quot; to save all emoji.
+      -s, --subdomain &lt;value>  slack subdomain. Can be specified multiple times, paired with respective token. (default: )
+      -t, --token &lt;value>      slack user token. ususaly starts xox*-... Can be specified multiple times, paired with respective subdomains. (default: )
       --bust-cache             force a redownload of all cached info.
-      --no-output              prevent writing of files.
+      --no-output              prevent writing of files in build/ and log/
+      --verbose                log debug messages to console
+      --save &lt;user>            save all of &lt;user>'s emoji to disk at build/$subdomain/$user
+      --save-all               save all emoji from all users to disk at build/$subdomain
+      --save-all-by-user       save all emoji from all users to disk at build/$subdomain/$user
+      -h, --help               output usage information
 
   upload                   upload emoji from json to given subdomain
       -s, --subdomain &lt;value>  slack subdomain. Can be specified multiple times, paired with respective token.
@@ -445,7 +449,7 @@ SLACK_REQUEST_WINDOW
 SLACK_REQUEST_CONCURRENCY=10 \
 SLACK_REQUEST_RATE=200 \
 SLACK_REQUEST_WINDOW=60000 \
-./emojme.js download --subdomain $SUBDOMAIN --token $TOKEN --saveAll --bust-cache
+./emojme.js download --subdomain $SUBDOMAIN --token $TOKEN --save-all --bust-cache
 </code></pre><p>I have tried my darndest to make the slack client in this project 429 tolerant, but after a few ignored 429's Slack gets mean and says you can't try again, so have fun dealing with that.</p>
 <h3>FAQ</h3><ul>
 <li><p>I don't see any progress when I run a cli command</p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -427,10 +427,38 @@ There are other fields in an adminList, but no others are used at the current ti
 <pre class="prettyprint source"><code>./emojme.js sync --subdomain $SUBDOMAIN1 --token $TOKEN1 --subdomain $SUBDOMAIN2 --token $TOKEN2</code></pre><ul>
 <li>sync emoji from $SUBDOMAIN1 to $SUBDOMAIN2<pre class="prettyprint source"><code>./emojme.js sync --src-subdomain $SUBDOMAIN1 --src-token $TOKEN1 --dst-subdomain $SUBDOMAIN2 --dst-token $TOKEN2</code></pre></li>
 </ul>
-<h2>Extra maybe helpful pro moves commands</h2><h3>Getting a list of single attributes from an adminList json:</h3><p>Hey try this with $ATTRIBUTE of &quot;url&quot;. You might need all those urls!</p>
+<h2>Pro Moves :promoves:</h2><h3>Getting a list of single attributes from an adminList json:</h3><p>Hey try this with $ATTRIBUTE of &quot;url&quot;. You might need all those urls!</p>
 <pre class="prettyprint source"><code>cat $ADMINLIST.json | jq '.[] | .[&quot;$ATTRIBUTE&quot;]'</code></pre><h3>Finding a slack token</h3><p>It's easy! Open any signed in slack window, e.g. subdomain.slack.com/messages, right click anywhere &gt; inspect element. Open the console and paste:</p>
 <pre class="prettyprint source"><code>window.prompt(&quot;your api token is: &quot;,/api_token: &quot;(.*)&quot;/.exec(document.body.innerHTML)[1])</code></pre><p>You will be prompted with your api token! From what I can tell these last anywhere from a few days to indefinitely. Currently, user tokens follow the format:
 <code>xox[sp]-(\w{12}|\w{10})-(\w{12}|\w{11})-\w{12}-\w{64}</code> but admittedly I have a small sample size.</p>
+<h3>Rate limiting and you</h3><p>Slack <a href="https://api.slack.com/changelog/2018-03-great-rate-limits">threatened to release</a> then <a href="https://api.slack.com/docs/rate-limits">released</a> rate limiting rules across its new api endpoints, and the rollout has included their undocumented endpoints now as well. As such, Emojme is going to slow down :capysad: Another nail in the coffin of making this a useful slackbot.</p>
+<p>Though it is unpublished, I have on good authority that <code>/emoji.adminList</code> is Tier 3 (when paginated) and <code>/emoji.add</code> is Tier 2, so emojme now has a &quot;fast part&quot; and a &quot;slow part&quot; respectively.</p>
+<p>I'm not one to judge how a person uses their own credentials, so there is a work around for those looking to get a bit more personal with the Slack networking infra team; Use the following environment variables to override my conservative defaults:</p>
+<pre class="prettyprint source lang-sh"><code># How many requests to make at a time. Higher numbers are faster (as long as the other two params allow) and more prone to trip Slack's &quot;hey that's not a burst that's a malicous user&quot; alarm
+SLACK_REQUEST_CONCURRENCY
+# How many requests are to be sent per unit time. This is the real control of speed, the higher the more likely you are to be rate limited.
+SLACK_REQUEST_RATE
+# The unit of time, in ms. The lower the number the faster.
+SLACK_REQUEST_WINDOW
+
+# So, an example that has 10 in-flight requests at a time at a maximum rate of 200 requests per minute would be:
+SLACK_REQUEST_CONCURRENCY=10 \
+SLACK_REQUEST_RATE=200 \
+SLACK_REQUEST_WINDOW=60000 \
+./emojme.js download --subdomain $SUBDOMAIN --token $TOKEN --saveAll --bust-cache
+</code></pre><p>I have tried my darndest to make the slack client in this project 429 tolerant, but after a few ignored 429's Slack gets mean and says you can't try again, so have fun dealing with that.</p>
+<h3>FAQ</h3><ul>
+<li><p>I don't see any progress when I run a cli command</p>
+<ul>
+<li>Do you have <code>--verbose</code> in your command? that's pretty useful.</li>
+</ul>
+</li>
+<li><p>My network requests are slow and jerky</p>
+<ul>
+<li>That's how we gotta live under <a href="#rate-limiting-and-you">rate limiting</a>. To speed things up, try the env vars that are listed, but things might not go well. To make things less jerkey, knock down the concurrency so requests are more serial and there is no down time between bursts.</li>
+</ul>
+</li>
+</ul>
 <h2>Inspirations</h2><ul>
 <li><a href="https://github.com/lambtron/emojipacks">emojipacks</a> is my OG. It mostly worked but seems rather undermaintained.</li>
 <li><a href="https://github.com/Fauntleroy/neutral-face-emoji-tools">neutral-face-emoji-tools</a> is a fantastic tool that has enabled me to make enough emoji that this tool became necessary.</li>

--- a/emojme-download.js
+++ b/emojme-download.js
@@ -70,7 +70,7 @@ async function download(subdomains, tokens, options) {
     const emojiList = await adminList.get(options.bustCache);
     if ((options.save && options.save.length) || options.saveAll || options.saveAllByUser) {
       saveResults = saveResults.concat(await EmojiAdminList.save(emojiList, subdomain, {
-        save: options.save, saveAll: options.saveAll, saveAllByUser: options.saveAllByUser
+        save: options.save, saveAll: options.saveAll, saveAllByUser: options.saveAllByUser,
       }));
     }
 

--- a/lib/emoji-add.js
+++ b/lib/emoji-add.js
@@ -15,7 +15,7 @@ class EmojiAdd {
     this.subdomain = subdomain;
     this.token = token;
     this.output = output || false;
-    this.slack = new SlackClient(this.subdomain);
+    this.slack = new SlackClient(this.subdomain, SlackClient.rateLimitTier(2));
     this.endpoint = ENDPOINT;
   }
 

--- a/lib/emoji-add.js
+++ b/lib/emoji-add.js
@@ -21,12 +21,17 @@ class EmojiAdd {
 
   async uploadSingle(emoji) {
     const parts = await this.constructor.createMultipart(emoji, this.token);
-    const body = await this.slack.request(this.endpoint, parts);
-    if (!body.ok) {
-      logger.warning(`[${this.subdomain}] error on ${emoji.name}: ${body.error}`);
-      return Object.assign({}, emoji, { error: body.error });
+    try {
+      const body = await this.slack.request(this.endpoint, parts);
+      if (!body.ok) {
+        throw new Error(body.error);
+      }
+    } catch (err) {
+      logger.warning(`[${this.subdomain}] error on ${emoji.name}: ${err.message || err}`);
+      return Object.assign({}, emoji, { error: err.message || err });
     }
     logger.debug(`[${this.subdomain}] ${emoji.name} uploaded successfully`);
+
     return false; // no error
   }
 

--- a/lib/emoji-admin-list.js
+++ b/lib/emoji-admin-list.js
@@ -146,8 +146,8 @@ class EmojiAdminList {
   static async save(emojiList, subdomain, options) {
     const groupedEmoji = _.groupBy(emojiList, 'user_display_name');
     const promiseArray = [];
-    let subdomainDirCreated = options.saveAll ? false : true;
-    let users = (options.saveAll || options.saveAllByUser)
+    let subdomainDirCreated = !options.saveAll;
+    const users = (options.saveAll || options.saveAllByUser)
       ? Object.keys(groupedEmoji)
       : Helpers.arrayify(options.save);
 
@@ -170,6 +170,7 @@ class EmojiAdminList {
       }
 
       return groupedEmoji[user].forEach((emoji) => {
+        let path = `${dirPath}/${emoji.name}`;
         try {
           let fileType;
           if (emoji.url.match(/^.*\.(gif|png|jpg|jpg)$/)) {
@@ -179,7 +180,7 @@ class EmojiAdminList {
           } else {
             throw new Error('unable to retrieve emoji source url');
           }
-          const path = `${dirPath}/${emoji.name}.${fileType}`;
+          path += `.${fileType}`;
 
           promiseArray.push(FileUtils.getData(emoji.url)
             .then(emojiData => FileUtils.saveData(emojiData, path))

--- a/lib/emoji-admin-list.js
+++ b/lib/emoji-admin-list.js
@@ -18,7 +18,7 @@ class EmojiAdminList {
     this.subdomain = subdomain;
     this.token = token;
     this.output = output || false;
-    this.slack = new SlackClient(this.subdomain);
+    this.slack = new SlackClient(this.subdomain, SlackClient.rateLimitTier(3));
     this.endpoint = ENDPOINT;
     this.pageSize = PAGE_SIZE;
   }

--- a/lib/emoji-admin-list.js
+++ b/lib/emoji-admin-list.js
@@ -1,5 +1,6 @@
 const _ = require('lodash');
 
+const Throttle = require('superagent-throttle');
 const logger = require('./logger');
 const SlackClient = require('./slack-client');
 const FileUtils = require('./util/file-utils');
@@ -146,6 +147,15 @@ class EmojiAdminList {
   static async save(emojiList, subdomain, options) {
     const groupedEmoji = _.groupBy(emojiList, 'user_display_name');
     const promiseArray = [];
+    const specialTier = SlackClient.rateLimitTier('special');
+    const throttle = new Throttle({
+      concurrent: process.env.SLACK_REQUEST_CONCURRENCY
+        || specialTier.slackRequestConcurrency,
+      rate: process.env.SLACK_REQUEST_RATE
+        || specialTier.slackRequestRate,
+      ratePer: process.env.SLACK_REQUEST_WINDOW
+        || specialTier.slackRequestWindow,
+    });
     let subdomainDirCreated = !options.saveAll;
     const users = (options.saveAll || options.saveAllByUser)
       ? Object.keys(groupedEmoji)
@@ -182,7 +192,7 @@ class EmojiAdminList {
           }
           path += `.${fileType}`;
 
-          promiseArray.push(FileUtils.getData(emoji.url)
+          promiseArray.push(FileUtils.getData(emoji.url, { throttle })
             .then(emojiData => FileUtils.saveData(emojiData, path))
             .then(() => { logger.debug(`[${subdomain}] saved ${emoji.name} to ${path}`); return path; }));
         } catch (err) {

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -15,6 +15,12 @@ const logger = winston.createLogger({
     // log everything to a file
     new winston.transports.File({
       filename: 'log/combined.log',
+      format: winston.format.combine(
+        winston.format.timestamp({
+          format: 'YYY-MM-DD hh:mm:ss A ZZ',
+        }),
+        winston.format.json(),
+      ),
       prettyPrint: true,
       timestamp: true,
       level: 'debug',

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -7,19 +7,19 @@ const logger = winston.createLogger({
     new winston.transports.Console({
       format: winston.format.combine(
         winston.format.colorize(),
-        winston.format.simple()
+        winston.format.simple(),
       ),
       colorize: true,
-      level: 'warning'
+      level: 'warning',
     }),
     // log everything to a file
     new winston.transports.File({
       filename: 'log/combined.log',
       prettyPrint: true,
       timestamp: true,
-      level: 'debug'
+      level: 'debug',
     }),
-  ]
+  ],
 });
 
 module.exports = logger;

--- a/lib/slack-client.js
+++ b/lib/slack-client.js
@@ -1,8 +1,8 @@
 const _ = require('lodash');
 const superagent = require('superagent');
 const Throttle = require('superagent-throttle');
-const logger = require('./logger');
 const sleep = require('util').promisify(setTimeout);
+const logger = require('./logger');
 
 class SlackClient {
   constructor(subdomain) {
@@ -67,13 +67,12 @@ class SlackClient {
       // Sometimes throttling our requests isn't enough and we still get rate limited.
       // In those cases, retry the request after however long Slack asks us to wait.
       if ((err.status === 429) && (retryAfter = err.response.headers['retry-after'] * 1000)) {
-        logger.warning(`Retrying ${endpoint} with ${parts.name} in ${retryAfter} ms`);
+        logger.info(`Retrying ${endpoint} with ${parts.name} in ${retryAfter} ms`);
         await sleep(retryAfter);
-        logger.warning(`Retrying ${endpoint} with ${parts.name} now`);
-        return await this.request(endpoint, parts)
-      } else {
-        throw new Error(`Caught error from Superagent "${err.message}" for req to ${endpoint}, ${parts.name}`);
+        logger.debug(`Retrying ${endpoint} with ${parts.name} now`);
+        await this.request(endpoint, parts);
       }
+      throw new Error(`Caught error from Superagent "${err.message}" for req to ${endpoint}, ${parts.name}`);
     }
   }
 }

--- a/lib/slack-client.js
+++ b/lib/slack-client.js
@@ -13,9 +13,9 @@ class SlackClient {
     // it as an acceptable "burst".
     this.throttle = new Throttle({
       active: true,
-      concurrent: 10,
-      rate: 50,
-      ratePer: 60000,
+      concurrent: process.env.SLACK_REQUEST_CONCURRENCY || 10,
+      rate: process.env.SLACK_REQUEST_RATE || 45,
+      ratePer: process.env.SLACK_REQUEST_WINDOW || 61000,
     });
     this.manualRetries = [];
   }

--- a/lib/slack-client.js
+++ b/lib/slack-client.js
@@ -25,6 +25,11 @@ const RATE_LIMIT_TIER = {
     slackRequestRate: 100,
     slackRequestWindow: 60000,
   },
+  special: {
+    slackRequestConcurrency: 200,
+    slackRequestRate: 3000,
+    slackRequestWindow: 60000,
+  },
 };
 
 class SlackClient {

--- a/lib/slack-client.js
+++ b/lib/slack-client.js
@@ -67,9 +67,9 @@ class SlackClient {
       // Sometimes throttling our requests isn't enough and we still get rate limited.
       // In those cases, retry the request after however long Slack asks us to wait.
       if ((err.status === 429) && (retryAfter = err.response.headers['retry-after'] * 1000)) {
-        logger.info(`Retrying ${endpoint} with ${parts.name} in ${retryAfter} ms`);
+        logger.info(`[${this.subdomain}] Retrying ${endpoint} with ${parts.name} in ${retryAfter} ms`);
         await sleep(retryAfter);
-        logger.debug(`Retrying ${endpoint} with ${parts.name} now`);
+        logger.debug(`[${this.subdomain}] Retrying ${endpoint} with ${parts.name} now`);
         await this.request(endpoint, parts);
       }
       throw new Error(`Caught error from Superagent "${err.message}" for req to ${endpoint}, ${parts.name}`);

--- a/lib/slack-client.js
+++ b/lib/slack-client.js
@@ -4,18 +4,47 @@ const Throttle = require('superagent-throttle');
 const sleep = require('util').promisify(setTimeout);
 const logger = require('./logger');
 
+const RATE_LIMIT_TIER = {
+  1: {
+    slackRequestConcurrency: 1,
+    slackRequestRate: 1,
+    slackRequestWindow: 60000,
+  },
+  2: {
+    slackRequestConcurrency: 5,
+    slackRequestRate: 20,
+    slackRequestWindow: 60000,
+  },
+  3: {
+    slackRequestConcurrency: 12,
+    slackRequestRate: 50,
+    slackRequestWindow: 60000,
+  },
+  4: {
+    slackRequestConcurrency: 25,
+    slackRequestRate: 100,
+    slackRequestWindow: 60000,
+  },
+};
+
 class SlackClient {
-  constructor(subdomain) {
+  constructor(subdomain, options) {
     this.subdomain = subdomain;
-    // Throttle requests to Slacks "Tier 3" limit,
-    // 50 requests per minute, or one request per 1200ms.
+    this.backoffTime = 0;
+    this.backoffs = [];
+    // If not otherwise specified, use tier 2 rate limiting
+    this.options = Object.assign(this.constructor.rateLimitTier(2), options);
+    // Throttle requests to Slacks "Tier 2" limit,
+    // 20 requests per minute, or one request per 3000ms.
     // Run a few requests simultaneously and hope Slack treats
     // it as an acceptable "burst".
     this.throttle = new Throttle({
-      active: true,
-      concurrent: process.env.SLACK_REQUEST_CONCURRENCY || 1,
-      rate: process.env.SLACK_REQUEST_RATE || 50,
-      ratePer: process.env.SLACK_REQUEST_WINDOW || 60000,
+      concurrent: process.env.SLACK_REQUEST_CONCURRENCY
+        || this.options.slackRequestConcurrency,
+      rate: process.env.SLACK_REQUEST_RATE
+        || this.options.slackRequestRate,
+      ratePer: process.env.SLACK_REQUEST_WINDOW
+        || this.options.slackRequestWindow,
     });
   }
 
@@ -40,6 +69,7 @@ class SlackClient {
   }
 
   async request(endpoint, parts) {
+    await sleep(this.backoffTime);
     const req = superagent.post(this.url(endpoint));
     req.use(this.throttle.plugin());
     if (parts) {
@@ -54,25 +84,43 @@ class SlackClient {
 
     try {
       const res = await req;
+
+      if (this.backoffs.length) {
+        this.backoffTime -= this.backoffs.pop();
+      } else {
+        this.throttle.options({ concurrent: this.slackRequestConcurrency });
+      }
+
       if (!res.body) {
         throw new Error('No body received from slack');
       }
       if (res.statusCode >= 400) {
         throw new Error(`Error response: ${res.statusCode} for req ${req.body}`);
       }
+
       return res.body;
     } catch (err) {
       let retryAfter;
+
       // Sometimes throttling our requests isn't enough and we still get rate limited.
       // In those cases, retry the request after however long Slack asks us to wait.
       if ((err.status === 429) && (retryAfter = err.response.headers['retry-after'] * 1000)) {
-        logger.info(`[${this.subdomain}] Retrying ${endpoint} with ${parts.name} in ${retryAfter} ms`);
-        await sleep(retryAfter);
-        logger.debug(`[${this.subdomain}] Retrying ${endpoint} with ${parts.name} now`);
-        return await this.request(endpoint, parts);
+        logger.info(`[${this.subdomain}] Rate limiting detected.`);
+        logger.debug(`[${this.subdomain}] Endpoint ${this.endpoint} rate limited. Will retry request ${JSON.stringify(parts)} after ${retryAfter} second backoff`);
+
+        // Prevent sending multiple requests later and re-angering the rate limiter
+        this.throttle.options({ concurrent: 1 });
+        this.backoffTime += retryAfter;
+        this.backoffs.push(retryAfter);
+
+        return this.request(endpoint, parts);
       }
       throw new Error(`Caught error from Superagent "${err.message}" for req to ${endpoint}, ${parts.name}`);
     }
+  }
+
+  static rateLimitTier(tier) {
+    return RATE_LIMIT_TIER[tier];
   }
 }
 

--- a/lib/slack-client.js
+++ b/lib/slack-client.js
@@ -1,15 +1,23 @@
 const _ = require('lodash');
 const superagent = require('superagent');
 const Throttle = require('superagent-throttle');
+const logger = require('./logger');
+const sleep = require('util').promisify(setTimeout);
 
 class SlackClient {
   constructor(subdomain) {
     this.subdomain = subdomain;
+    // Throttle requests to Slacks "Tier 3" limit,
+    // 50 requests per minute, or one request per 1200ms.
+    // Run a few requests simultaneously and hope Slack treats
+    // it as an acceptable "burst".
     this.throttle = new Throttle({
       active: true,
       concurrent: 10,
-      rate: Infinity,
+      rate: 50,
+      ratePer: 60000,
     });
+    this.manualRetries = [];
   }
 
   url(endpoint) {
@@ -45,14 +53,28 @@ class SlackClient {
       });
     }
 
-    const res = await req;
-    if (!res.body) {
-      throw new Error('No body received from slack');
+    try {
+      const res = await req;
+      if (!res.body) {
+        throw new Error('No body received from slack');
+      }
+      if (res.statusCode >= 400) {
+        throw new Error(`Error response: ${res.statusCode} for req ${req.body}`);
+      }
+      return res.body;
+    } catch (err) {
+      let retryAfter;
+      // Sometimes throttling our requests isn't enough and we still get rate limited.
+      // In those cases, retry the request after however long Slack asks us to wait.
+      if ((err.status === 429) && (retryAfter = err.response.headers['retry-after'] * 1000)) {
+        logger.warning(`Retrying ${endpoint} with ${parts.name} in ${retryAfter} ms`);
+        await sleep(retryAfter);
+        logger.warning(`Retrying ${endpoint} with ${parts.name} now`);
+        return await this.request(endpoint, parts)
+      } else {
+        throw new Error(`Caught error from Superagent "${err.message}" for req to ${endpoint}, ${parts.name}`);
+      }
     }
-    if (res.statusCode >= 400) {
-      throw new Error(`Error response: ${res.statusCode} for req ${req.body}`);
-    }
-    return res.body;
   }
 }
 

--- a/lib/slack-client.js
+++ b/lib/slack-client.js
@@ -13,11 +13,10 @@ class SlackClient {
     // it as an acceptable "burst".
     this.throttle = new Throttle({
       active: true,
-      concurrent: process.env.SLACK_REQUEST_CONCURRENCY || 10,
-      rate: process.env.SLACK_REQUEST_RATE || 45,
-      ratePer: process.env.SLACK_REQUEST_WINDOW || 61000,
+      concurrent: process.env.SLACK_REQUEST_CONCURRENCY || 1,
+      rate: process.env.SLACK_REQUEST_RATE || 50,
+      ratePer: process.env.SLACK_REQUEST_WINDOW || 60000,
     });
-    this.manualRetries = [];
   }
 
   url(endpoint) {
@@ -70,7 +69,7 @@ class SlackClient {
         logger.info(`[${this.subdomain}] Retrying ${endpoint} with ${parts.name} in ${retryAfter} ms`);
         await sleep(retryAfter);
         logger.debug(`[${this.subdomain}] Retrying ${endpoint} with ${parts.name} now`);
-        await this.request(endpoint, parts);
+        return await this.request(endpoint, parts);
       }
       throw new Error(`Caught error from Superagent "${err.message}" for req to ${endpoint}, ${parts.name}`);
     }

--- a/lib/util/file-utils.js
+++ b/lib/util/file-utils.js
@@ -57,14 +57,20 @@ function saveData(data, path) {
   });
 }
 
-async function getData(path) {
+async function getData(path, options) {
   path = path || '';
+  options = options || {};
+
   try {
     if (path.match(/^http.*/)) {
-      const res = await superagent.get(path)
-        .retry(3)
-        .buffer(true)
-        .parse(superagent.parse.image);
+      const req = superagent.get(path);
+      req.retry(3);
+      req.buffer(true);
+      if (options.throttle) {
+        req.use(options.throttle.plugin());
+      }
+      const res = await req.parse(superagent.parse.image);
+
       return res.body;
     } if (path.match(/^data:/)) {
       return path.replace(/^.*base64,/, '');

--- a/lib/util/file-utils.js
+++ b/lib/util/file-utils.js
@@ -52,7 +52,7 @@ function isExpired(path) {
 
 function saveData(data, path) {
   this.mkdirp('build');
-  return new Promise((resolve, reject) => {
+  return new Promise((resolve) => {
     resolve(fs.writeFileSync(path, data, { encoding: 'base64' }));
   });
 }
@@ -67,12 +67,12 @@ async function getData(path) {
         .parse(superagent.parse.image);
       return res.body;
     } if (path.match(/^data:/)) {
-      return path.replace(/^.*base64,/,'');
+      return path.replace(/^.*base64,/, '');
     } if (path.match(/\.(gif|jpg|jpeg|png)/) && fs.existsSync(path)) {
       return fs.readFileSync(path);
     }
     throw new Error('Emoji Url does not contain acceptable data');
-  } catch(e) {
+  } catch (e) {
     throw e;
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "js-yaml": "^3.12.0",
     "lodash": "^4.17.10",
     "superagent": "^3.8.3",
-    "superagent-retry": "^0.6.0",
     "superagent-throttle": "^1.0.0",
     "winston": "^3.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "commander": "^2.17.1",
     "graceful-fs": "^4.1.11",
     "js-yaml": "^3.12.0",
-    "lodash": "^4.17.10",
+    "lodash": "^4.17.11",
     "superagent": "^3.8.3",
     "superagent-throttle": "^1.0.0",
     "winston": "^3.1.0"
@@ -47,7 +47,7 @@
   "devDependencies": {
     "chai": "^4.1.2",
     "chai-shallow-deep-equal": "^1.4.6",
-    "eslint": "^5.7.0",
+    "eslint": "^5.13.0",
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-plugin-import": "^2.14.0",
     "jsdoc": "3.5.5",

--- a/spec/integration/emojme-add-spec.js
+++ b/spec/integration/emojme-add-spec.js
@@ -11,10 +11,11 @@ const FileUtils = require('../../lib/util/file-utils');
 const add = require('../../emojme-add').add;
 const addCli = require('../../emojme-add').addCli;
 
-var logger = require('../../lib/logger');
+const logger = require('../../lib/logger');
 
 let sandbox;
-let warningSpy, infoSpy, debugSpy;
+let warningSpy; let infoSpy; let
+  debugSpy;
 
 beforeEach(() => {
   sandbox = sinon.createSandbox();
@@ -181,7 +182,7 @@ describe('add', () => {
           '--name', 'emoji-2', '--alias-for', 'emoji',
           '--name', 'emoji-3', '--alias-for', 'emoji',
           '--name', 'emoji-4', '--alias-for', 'emoji',
-          '--verbose'
+          '--verbose',
         ];
 
         return addCli().then(validateResults);

--- a/spec/integration/emojme-download-spec.js
+++ b/spec/integration/emojme-download-spec.js
@@ -91,9 +91,7 @@ describe('download', () => {
       assert.deepEqual(results.subdomain.emojiList, specHelper.testEmojiList(10));
 
       assert.equal(results.subdomain.saveResults.length, 10);
-      results.subdomain.saveResults.map(path => {
-        return assert.match(path, /build\/subdomain\/emoji-[0-9]*.jpg/);
-      });
+      results.subdomain.saveResults.map(path => assert.match(path, /build\/subdomain\/emoji-[0-9]*.jpg/));
     });
 
     it('using the cli', () => {
@@ -103,13 +101,13 @@ describe('download', () => {
         'download',
         '--subdomain', 'subdomain',
         '--token', 'token',
-        '--save-all'
+        '--save-all',
       ];
       return downloadCli().then(validateResults);
     });
 
     it('using the module', () => {
-      download('subdomain', 'token', {saveAll: true}).then(validateResults);
+      download('subdomain', 'token', { saveAll: true }).then(validateResults);
     });
   });
 
@@ -119,9 +117,7 @@ describe('download', () => {
 
       assert.equal(results.subdomain.saveResults.length, 10);
 
-      results.subdomain.saveResults.map(path => {
-        return assert.match(path, /build\/subdomain\/test-user-[0-9]\/emoji-[0-9]*.jpg/);
-      });
+      results.subdomain.saveResults.map(path => assert.match(path, /build\/subdomain\/test-user-[0-9]\/emoji-[0-9]*.jpg/));
     });
 
     it('using the cli', () => {
@@ -131,13 +127,13 @@ describe('download', () => {
         'download',
         '--subdomain', 'subdomain',
         '--token', 'token',
-        '--save-all-by-user'
+        '--save-all-by-user',
       ];
       return downloadCli().then(validateResults);
     });
 
     it('using the module', () => {
-      download('subdomain', 'token', {saveAllByUser: true}).then(validateResults);
+      download('subdomain', 'token', { saveAllByUser: true }).then(validateResults);
     });
   });
 });

--- a/spec/unit/lib/emoji-add-spec.js
+++ b/spec/unit/lib/emoji-add-spec.js
@@ -8,15 +8,14 @@ const logger = require('../../../lib/logger');
 
 const specHelper = require('../../spec-helper');
 
-let sandbox, emojiAdd, warningSpy, infoSpy, debugSpy;
+let sandbox; let emojiAdd; let
+  infoSpy;
 
 beforeEach(() => {
   sandbox = sinon.createSandbox();
   emojiAdd = new EmojiAdd('subdomain', 'token');
 
-  warningSpy = sandbox.spy(logger, 'warning');
   infoSpy = sandbox.spy(logger, 'info');
-  debugSpy = sandbox.spy(logger, 'debug');
 });
 
 afterEach(() => {
@@ -144,7 +143,7 @@ describe('EmojiAdd', () => {
       );
 
       return emojiAdd.upload('./spec/fixtures/emojiList.json').then((results) => {
-        let infoCalls = infoSpy.getCalls();
+        const infoCalls = infoSpy.getCalls();
 
         assert.deepEqual(results.errorList, []);
         assert.equal(infoSpy.callCount, 2);

--- a/spec/unit/lib/slack-client-spec.js
+++ b/spec/unit/lib/slack-client-spec.js
@@ -1,0 +1,39 @@
+const assert = require('chai').assert;
+const SlackClient = require('../../../lib/slack-client');
+
+describe('SlackClient', () => {
+  describe.only('constructor', () => {
+    const tierTwoLimits = SlackClient.rateLimitTier(2);
+    const tierThreeLimits = SlackClient.rateLimitTier(3);
+
+    it('defaults to using tier 2 rate limiting when no limits are specified', () => {
+      const slackClient = new SlackClient('subdomain');
+
+      assert.deepEqual(slackClient.options, tierTwoLimits);
+    });
+
+    it('allows rate limit tier overrides to be set', () => {
+      const slackClient = new SlackClient('subdomain', tierThreeLimits);
+
+      assert.deepEqual(slackClient.options, tierThreeLimits);
+    });
+
+    it('overrides passed variables with environment variables when present', () => {
+      process.env.SLACK_REQUEST_CONCURRENCY = 1;
+      process.env.SLACK_REQUEST_RATE = 2;
+      process.env.SLACK_REQUEST_WINDOW = 3;
+
+      const slackClient = new SlackClient('subdomain', tierThreeLimits);
+
+      assert.include(slackClient.throttle, {
+        concurrent: '1',
+        rate: '2',
+        ratePer: '3',
+      });
+
+      delete process.env.SLACK_REQUEST_CONCURRENCY;
+      delete process.env.SLACK_REQUEST_RATE;
+      delete process.env.SLACK_REQUEST_WINDOW;
+    });
+  });
+});


### PR DESCRIPTION
* Closes #33
* Makes SlackClient more 429 tolerant
* Decreases overall api request speed :(

What is going on
-----

Slack has [threatened](https://api.slack.com/changelog/2018-03-great-rate-limits), [implemented](https://api.slack.com/docs/rate-limits), and finally expanded its rate limiting to the emoji api endpoints. This means some of our heavier requests (see: uploading a shit ton of emoji as fast as possible) are catching 429's and generally having a bad time.

What we should do about it
-----

There are already some features in place for this, namely the inclusion of the superagent-throttle plugging. It works, but needs to be tuned to the endpoints we use to be respectful to the slack api. What tuning does it need? Well... I don't know. Because emojme is running on undocumented endpoints, the endpoints don't have an obvious "Tier" associated with them (refer to https://api.slack.com/docs/rate-limits for what I mean by tiers).

So what tier are we?
-----

Hard to say, as we can only (as of 02/10/2019) guess by approximating at this point, but here is my basis for thinking the emoji endpoints are **Tier 3**, 50+ per minute (Slack employees plz tell me if i'm wrong):

* Testing
    * Having set the throttler to Tier 4, with 100 concurrent requests per 60000ms, we're still seeing 429's. Que lastima.
    * Tested at a T2 rate and it was soooooo sloooow i couldn't wait for the test to finish but no 429's in the first 5 minutes or so.
* Comparisons
  * Tier 2 (20 req / minute) methods seem to refer to much heavier methods than an emoji add, which I assume to be at the same logic level as adding a message (though those are no doubt more prioritized), file (probably more similar), or post.
    * emoji.list (:grimace:) this one is _unpaginated_ and a db call, so it's gonna be pretty restricted
    * search.messages is a _heavy_ db call
    * files.upload _is_ a Tier 2 method, and may be similar to emoji, however I think emoji would be "easier" on slack due to size requirements.