### PR TITLE
Add Slack Auto-workspace feature to example link

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,7 +459,7 @@ From what I can tell these last anywhere from a few days to indefinitely. Curren
 
 #### Slack for Web
 
-It's easyish! Open and sign into the slack customization page, e.g. subdomain.slack.com/customize, right click anywhere > inspect element. Open the console and paste:
+It's easyish! Open and sign into the slack customization page, e.g. https://my.slack.com/customize, right click anywhere > inspect element. Open the console and paste:
 
 ```javascript
 window.prompt("your api token is: ", TS.boot_data.api_token)


### PR DESCRIPTION
Slack interprets my.slack.com to mean 'whateversubdomain I used last".slack.com

Can help someone worried about the timer.