### PR TITLE
Allow client.boot request to use cookie and fix params

### DIFF
--- a/lib/client-boot.js
+++ b/lib/client-boot.js
@@ -4,17 +4,20 @@ const SlackClient = require('./slack-client');
 const FileUtils = require('./util/file-utils');
 
 const ENDPOINT = '/client.boot';
+const FLANNEL_API_VER = '4';
 
 // Methods to upload emoji to slack.
 // Instance methods require slack client.
 // Static methods do not.
 class ClientBoot {
-  constructor(subdomain, token, output) {
+  constructor(subdomain, token, cookie, output) {
     this.subdomain = subdomain;
     this.token = token;
+    this.cookie = cookie;
     this.output = output || false;
-    this.slack = new SlackClient(this.subdomain, SlackClient.rateLimitTier(2));
+    this.slack = new SlackClient(this.subdomain, this.cookie, SlackClient.rateLimitTier(2));
     this.endpoint = ENDPOINT;
+    this.flannel_api_ver = FLANNEL_API_VER;
   }
 
   async get(bustCache) {
@@ -31,11 +34,12 @@ class ClientBoot {
   createMultipart() {
     return {
       token: this.token,
+      flannel_api_ver: this.flannel_api_ver,
     };
   }
 
   static extractEmojiUse(data) {
-    const emojiToUsageMap = JSON.parse(data.self.prefs.emoji_use);
+    const emojiToUsageMap = JSON.parse(data.prefs.emoji_use);
     const emojiToUsageArray = _.reduce(emojiToUsageMap, (acc, usage, name) => {
       acc.push({ name, usage });
       return acc;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "emojme",
   "description": "The Emojartist's toolbox for spreading their work across the slackosphere",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "keywords": [
     "emoji",
     "slack",


### PR DESCRIPTION
I need my emoji dopamine hit back. Now I can go back to breaking slack.

fixes #62 